### PR TITLE
Pass a message object to js.SDK driver, not a string

### DIFF
--- a/RocketChatBot.js
+++ b/RocketChatBot.js
@@ -77,15 +77,20 @@ function RocketChatBot(botkit, config) {
         bot.send = async function (message, cb) {
             console.log("\ninside bot.send")
             console.log(message)
+            
+            var newMessage = {
+                msg: message.text,
+            }
+            
             if (bot.connected) {
                 if (messageSource === 'directMessage') {
-                    await driver.sendDirectToUser(message.text, userName);
+                    await driver.sendDirectToUser(newMessage, userName);
                 } else if (messageSource === 'liveChat') {
                     // TODO: implement answer to livechat
                 } else if (messageSource === 'privateChannel') {
-                    await driver.sendToRoomId(message.text, roomID);
+                    await driver.sendToRoomId(newMessage, roomID);
                 } else if (messageSource === 'channel') {
-                    await driver.sendToRoomId(message.text, roomID);
+                    await driver.sendToRoomId(newMessage, roomID);
                 }
             }
         }

--- a/RocketChatBot.js
+++ b/RocketChatBot.js
@@ -80,6 +80,7 @@ function RocketChatBot(botkit, config) {
             
             var newMessage = {
                 msg: message.text,
+                attachments: message.attachments || []
             }
             
             if (bot.connected) {


### PR DESCRIPTION
This results in the attachments object getting passed through the connector to the clients. 