### PR TITLE
Add support for rich messages

### DIFF
--- a/RocketChatBot.js
+++ b/RocketChatBot.js
@@ -78,15 +78,15 @@ function RocketChatBot(botkit, config) {
             
             if (bot.connected) {
                 if (message.type === 'directMessage') {
-                      await driver.sendDirectToUser(message.text, message.user);
+                      await driver.sendDirectToUser(newMessage, message.user);
                 } else if (message.type === 'liveChat') {
                     // TODO: implement answer to livechat
                 } else if (message.type === 'privateChannel') {
-                      await driver.sendToRoomId(message.text, message.channel);
+                      await driver.sendToRoomId(newMessage, message.channel);
                 } else if (message.type === 'channel') {
-                      await driver.sendToRoomId(message.text, message.channel);
+                      await driver.sendToRoomId(newMessage, message.channel);
                 } else if (message.type === 'message') {
-                      await driver.sendToRoomId(message.text, message.channel);
+                      await driver.sendToRoomId(newMessage, message.channel);
                 }  
                 cb();
             }


### PR DESCRIPTION
Send a message object to the js.SDK.driver instead of just the text string.  

This works for now because the helper method `driver.sendDirectToUser()` is not using strict type checking and will accept and properly handle an IMessage.